### PR TITLE
Fix broken link (remove www.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ To run this
     npm install electron-prebuilt -g
     electron app
 
-Visit http://www.mylifeforthecode.com/making-the-electron-shell-as-pretty-as-the-visual-studio-shell/ for the tutorial
+Visit http://mylifeforthecode.com/making-the-electron-shell-as-pretty-as-the-visual-studio-shell/ for the tutorial


### PR DESCRIPTION
The website appears to no longer work with `www.` included in the URL.
